### PR TITLE
[controllers] add namespaced mode

### DIFF
--- a/controllers/capi2argo_reconciler.go
+++ b/controllers/capi2argo_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +21,8 @@ func init() {
 	if ArgoNamespace == "" {
 		ArgoNamespace = "argocd"
 	}
+
+	EnableNamespacedNames, _ = strconv.ParseBool(os.Getenv("ENABLE_NAMESPACED_NAMES"))
 }
 
 // Capi2Argo reconciles a Secret object

--- a/controllers/constructs_test.go
+++ b/controllers/constructs_test.go
@@ -2,10 +2,11 @@ package controllers
 
 import (
 	b64 "encoding/base64"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockCapiCluster returns a based64-encoded string that
@@ -75,7 +76,7 @@ func MockArgoCluster(validMock bool) *ArgoCluster {
 	}
 
 	a := &ArgoCluster{
-		NamespacedName: BuildNamespacedName("test"),
+		NamespacedName: BuildNamespacedName("test", "test"),
 		ClusterName:    "test",
 		ClusterServer:  "server",
 		ClusterConfig: ArgoConfig{


### PR DESCRIPTION
In namespaced mode whenever the cluster name is used in the generated Argo secret the CAPI secret namespace is prepended.

This allows running the controller in an environment where clusters of the same name could be created in different namespaces.

Namespaced mode is activated by setting the env var `ENABLE_NAMESPACED_NAMES=true`.