### PR TITLE
Added a label to ignore clusters.

### DIFF
--- a/controllers/argo_cluster.go
+++ b/controllers/argo_cluster.go
@@ -27,6 +27,7 @@ var (
 const (
 	clusterTakeAlongKey        = "take-along-label.capi-to-argocd."
 	clusterTakenFromClusterKey = "taken-from-cluster-label.capi-to-argocd."
+	clusterIgnoreKey           = "ignore-cluster.capi-to-argocd"
 )
 
 // GetArgoCommonLabels holds a map of labels that reconciled objects must have.
@@ -105,6 +106,18 @@ func extractTakeAlongLabel(key string) (string, error) {
 	}
 	// Not an take-along label. Return nil
 	return "", nil
+}
+
+// validateClusterIgnoreLabel returns true when the cluster has the clusterIgnoreKey label
+func validateClusterIgnoreLabel(cluster *clusterv1.Cluster) bool {
+	clusterLabels := cluster.Labels
+
+	for k := range clusterLabels {
+		if k == clusterIgnoreKey {
+			return true
+		}
+	}
+	return false
 }
 
 // buildTakeAlongLabels returns a list of valid take-along labels from a cluster

--- a/controllers/capi2argo_reconciler.go
+++ b/controllers/capi2argo_reconciler.go
@@ -120,6 +120,12 @@ func (r *Capi2Argo) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 		log.Info("Failed to get Cluster object", "error", err)
 	}
 
+	// Check if the cluster has the ignore label
+	if validateClusterIgnoreLabel(clusterObject) {
+		log.Info("The cluster has label to be ignored, skipping...")
+		return ctrl.Result{}, nil
+	}
+
 	// Construct ArgoCluster from CapiCluster and CapiSecret.Metadata.
 	argoCluster, err := NewArgoCluster(capiCluster, &capiSecret, clusterObject)
 	if err != nil {


### PR DESCRIPTION
There are cases that a specific cluster should be ignored from capi2argocd operator. One such case is when the cluster that manages the clusterapi resources is managed by clusterapi itself. The capi2argocd in this case would try to create cluster in argocd with the external credentials provided by clusterapi while argocd already knows how to use this cluster using the internal address (as it is itself).

This pull request allows to define a label on the clusters `ignore-cluster.capi-to-argocd` and when that exists the cluster is skipped by cap2argo-cluster-operator.