### PR TITLE
feat: add namespace filtering and rewrite README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@
 name: "CI"
 on:
   push:
-      paths:
+    branches: [main]
+    paths:
       - '.github/workflows/*'
       - 'controllers/*'
       - 'vendor/*'
@@ -10,7 +11,7 @@ on:
       - 'go.sum'
       - 'main.go'
   pull_request:
-      paths:
+    paths:
       - '.github/workflows/*'
       - 'controllers/*'
       - 'vendor/*'
@@ -40,7 +41,7 @@ jobs:
       - name: Run go lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.8.0
           args: --timeout 5m --modules-download-mode=vendor --build-tags integration
 
       - name: Run go test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -31,7 +31,7 @@ jobs:
           logout: false
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean --config .github/config/goreleaser.yaml
         env:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ USER = $(shell id -u)
 GROUP = $(shell id -g)
 PROJECT = "capi2argo-cluster-operator"
 GOBUILD_OPTS = -ldflags="-s -w -X ${PROJECT}/cmd.Version=${VERSION} -X ${PROJECT}/cmd.CommitHash=${COMMIT}"
-GO_IMAGE = "golang:1.24-alpine"
+GO_IMAGE = "golang:1.25-alpine"
 GO_IMAGE_CI = "golangci/golangci-lint:v2.1.6"
 DISTROLESS_IMAGE = "gcr.io/distroless/static:nonroot"
 IMAGE_TAG_BASE ?= "ghcr.io/dntosas/${PROJECT}"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GROUP = $(shell id -g)
 PROJECT = "capi2argo-cluster-operator"
 GOBUILD_OPTS = -ldflags="-s -w -X ${PROJECT}/cmd.Version=${VERSION} -X ${PROJECT}/cmd.CommitHash=${COMMIT}"
 GO_IMAGE = "golang:1.25-alpine"
-GO_IMAGE_CI = "golangci/golangci-lint:v2.1.6"
+GO_IMAGE_CI = "golangci/golangci-lint:v2.8.0"
 DISTROLESS_IMAGE = "gcr.io/distroless/static:nonroot"
 IMAGE_TAG_BASE ?= "ghcr.io/dntosas/${PROJECT}"
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ metrics:
 
 ### Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A running Kubernetes cluster (or [kind](https://kind.sigs.k8s.io/) for local development)
 - [envtest](https://book.kubebuilder.io/reference/envtest.html) binaries (installed automatically via `make envtest`)
 

--- a/charts/capi2argo-cluster-operator/Chart.yaml
+++ b/charts/capi2argo-cluster-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.4.2
+appVersion: 1.5.0
 description: Capi-2-Argo Cluster Operator (CACO) converts ClusterAPI Cluster credentials into ArgoCD Cluster definitions and keep them synchronized.
 home: https://github.com/dntosas/capi2argo-cluster-operator
 keywords:
@@ -11,7 +11,7 @@ maintainers:
 name: capi2argo-cluster-operator
 sources:
 - https://github.com/dntosas/capi2argo-cluster-operator
-version: 1.4.2
+version: 1.5.0
 dependencies:
 - name: common
   repository: "https://charts.bitnami.com/bitnami"

--- a/charts/capi2argo-cluster-operator/README.md
+++ b/charts/capi2argo-cluster-operator/README.md
@@ -1,6 +1,6 @@
 # capi2argo-cluster-operator
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![AppVersion: 0.1.13](https://img.shields.io/badge/AppVersion-0.1.13-informational?style=flat-square)
+![Version: 1.5.5](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![AppVersion: 1.5.0](https://img.shields.io/badge/AppVersion-0.1.13-informational?style=flat-square)
 
 Capi-2-Argo Cluster Operator (CACO) converts ClusterAPI Cluster credentials into ArgoCD Cluster definitions and keep them synchronized.
 

--- a/charts/capi2argo-cluster-operator/templates/deployment.yaml
+++ b/charts/capi2argo-cluster-operator/templates/deployment.yaml
@@ -100,6 +100,10 @@ spec:
             - name: ENABLE_NAMESPACED_NAMES
               value: {{ .Values.namespacedNamesEnabled | squote }}
             {{- end }}
+            {{- if .Values.allowedNamespaces }}
+            - name: ALLOWED_NAMESPACES
+              value: {{ .Values.allowedNamespaces | squote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/capi2argo-cluster-operator/values.yaml
+++ b/charts/capi2argo-cluster-operator/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 image:
   registry: ghcr.io
   repository: dntosas/capi2argo-cluster-operator
-  tag: v1.4.2
+  tag: v1.5.0
   pullPolicy: Always
   pullSecrets: []
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/dntosas/capi2argo-cluster-operator
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.2
+toolchain go1.25.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Add support for restricting the controller to watch only specific
namespaces via a comma-separated list. Secrets in namespaces outside
the list are filtered at the watch predicate level and never trigger
reconciliation.

Configuration:
- ALLOWED_NAMESPACES env var (e.g. "team-a,team-b,production")
- allowedNamespaces Helm value (already existed, now wired to env var)
- Empty value means all namespaces (backward compatible)

Implementation:
- AllowedNamespaces field on Config struct
- parseNamespaceList() handles trimming, empty entries, edge cases
- IsNamespaceAllowed() method for clean predicate checks
- Watch predicate extended to filter by namespace alongside naming
- Helm deployment template passes ALLOWED_NAMESPACES env var
- 13 test cases covering parsing and namespace allow/deny logic

README rewrite:
- Clear problem/solution narrative
- Full configuration reference tables (env vars, Helm values, CLI flags)
- Document all features: namespace filtering, GC, ignore labels,
  take-along labels, auto label copy, namespaced names, Rancher
  support, Prometheus metrics
- Updated development section and roadmap
