### PR TITLE
feat: sync CAPI cluster annotations to ArgoCD secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ CACO is configured through environment variables (set via Helm values):
 | `ENABLE_GARBAGE_COLLECTION` | `garbageCollectionEnabled` | `false` | Delete ArgoCD secrets when the corresponding CAPI secret is deleted |
 | `ENABLE_NAMESPACED_NAMES` | `namespacedNamesEnabled` | `false` | Prepend cluster namespace to ArgoCD secret names to avoid collisions |
 | `ENABLE_AUTO_LABEL_COPY` | *(via `extraEnvVars`)* | `false` | Automatically copy all non-system labels from CAPI Cluster to ArgoCD secret |
+| `ENABLE_AUTO_ANNOTATION_COPY` | `autoAnnotationCopyEnabled` | `false` | Automatically copy all non-system annotations from CAPI Cluster to ArgoCD secret |
 
 ### CLI Flags
 
@@ -191,6 +192,57 @@ This copies every label from the Cluster resource to the ArgoCD secret, except:
 - `kubernetes.io/*` (system labels)
 - `cluster.x-k8s.io/*` (CAPI internal labels)
 - `capi-to-argocd/*` (controller internal labels)
+
+### Take-Along Annotations
+
+CACO can copy annotations from a `Cluster` resource to the generated ArgoCD secret. This is particularly useful for values that contain characters forbidden in Kubernetes labels (e.g., `/` in branch names like `feat/test`).
+
+Add an annotation with the format `take-along-annotation.capi-to-argocd.<annotation-key>: ""`:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: my-cluster
+  namespace: default
+  annotations:
+    my-branch-name: "feat/test"
+    my.domain.com/revision: "abc123"
+    take-along-annotation.capi-to-argocd.my-branch-name: ""
+    take-along-annotation.capi-to-argocd.my.domain.com/revision: ""
+```
+
+The resulting ArgoCD secret will include:
+
+```yaml
+metadata:
+  annotations:
+    my-branch-name: "feat/test"
+    my.domain.com/revision: "abc123"
+    taken-from-cluster-annotation.capi-to-argocd.my-branch-name: ""
+    taken-from-cluster-annotation.capi-to-argocd.my.domain.com/revision: ""
+```
+
+### Auto Annotation Copy
+
+As an alternative to take-along annotations, enable automatic copying of **all** non-system annotations:
+
+```bash
+ENABLE_AUTO_ANNOTATION_COPY=true
+```
+
+Or via Helm:
+
+```yaml
+# values.yaml
+autoAnnotationCopyEnabled: true
+```
+
+This copies every annotation from the Cluster resource to the ArgoCD secret, except:
+- `kubernetes.io/*` (system annotations)
+- `cluster.x-k8s.io/*` (CAPI internal annotations)
+- `capi-to-argocd/*` (controller internal annotations)
+- `kubectl.kubernetes.io/*` (kubectl bookkeeping annotations)
 
 ### Namespaced Names
 

--- a/charts/capi2argo-cluster-operator/templates/deployment.yaml
+++ b/charts/capi2argo-cluster-operator/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
             - name: ALLOWED_NAMESPACES
               value: {{ .Values.allowedNamespaces | squote }}
             {{- end }}
+            {{- if .Values.autoAnnotationCopyEnabled }}
+            - name: ENABLE_AUTO_ANNOTATION_COPY
+              value: {{ .Values.autoAnnotationCopyEnabled | squote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/capi2argo-cluster-operator/values.yaml
+++ b/charts/capi2argo-cluster-operator/values.yaml
@@ -19,6 +19,7 @@ image:
 argoCDNamespace: "argocd"
 namespacedNamesEnabled: false
 garbageCollectionEnabled: true
+autoAnnotationCopyEnabled: false
 
 dryRun: false
 debugMode: false

--- a/controllers/argo_cluster.go
+++ b/controllers/argo_cluster.go
@@ -18,6 +18,10 @@ const (
 	clusterTakeAlongKey        = "take-along-label.capi-to-argocd."
 	clusterTakenFromClusterKey = "taken-from-cluster-label.capi-to-argocd."
 	clusterIgnoreKey           = "ignore-cluster.capi-to-argocd"
+
+	// Annotation sync constants.
+	annotationTakeAlongKey        = "take-along-annotation.capi-to-argocd."
+	annotationTakenFromClusterKey = "taken-from-cluster-annotation.capi-to-argocd."
 )
 
 // GetArgoCommonLabels holds a map of labels that reconciled objects must have.
@@ -30,12 +34,13 @@ func GetArgoCommonLabels() map[string]string {
 
 // ArgoCluster holds all information needed for CAPI --> Argo Cluster conversion.
 type ArgoCluster struct {
-	NamespacedName  types.NamespacedName
-	ClusterName     string
-	ClusterServer   string
-	ClusterLabels   map[string]string
-	TakeAlongLabels map[string]string
-	ClusterConfig   ArgoConfig
+	NamespacedName       types.NamespacedName
+	ClusterName          string
+	ClusterServer        string
+	ClusterLabels        map[string]string
+	TakeAlongLabels      map[string]string
+	TakeAlongAnnotations map[string]string
+	ClusterConfig        ArgoConfig
 }
 
 // ArgoConfig represents Argo Cluster.JSON.config.
@@ -56,12 +61,20 @@ func NewArgoCluster(c *CapiCluster, s *corev1.Secret, cluster *clusterv1.Cluster
 	log := ctrl.Log.WithName("argoCluster")
 
 	takeAlongLabels := map[string]string{}
+	takeAlongAnnotations := map[string]string{}
 
 	var errList []string
 
 	if cluster != nil {
 		takeAlongLabels, errList = buildTakeAlongLabels(cluster, cfg)
 		for _, e := range errList {
+			log.Info(e)
+		}
+
+		var annotationErrs []string
+
+		takeAlongAnnotations, annotationErrs = buildTakeAlongAnnotations(cluster, cfg)
+		for _, e := range annotationErrs {
 			log.Info(e)
 		}
 	}
@@ -74,7 +87,8 @@ func NewArgoCluster(c *CapiCluster, s *corev1.Secret, cluster *clusterv1.Cluster
 			"capi-to-argocd/cluster-secret-name": c.Name + "-kubeconfig",
 			"capi-to-argocd/cluster-namespace":   c.Namespace,
 		},
-		TakeAlongLabels: takeAlongLabels,
+		TakeAlongLabels:      takeAlongLabels,
+		TakeAlongAnnotations: takeAlongAnnotations,
 		ClusterConfig: ArgoConfig{
 			BearerToken: c.KubeConfig.Users[0].User.Token,
 			TLSClientConfig: &ArgoTLS{
@@ -141,50 +155,98 @@ func buildAutoLabelCopy(clusterLabels map[string]string) map[string]string {
 
 // buildTakeAlongLabels returns valid take-along labels from a cluster.
 // If Config.EnableAutoLabelCopy is true, it copies all non-system labels automatically.
-// Otherwise, it uses the take-along label mechanism for backward compatibility.
+// Otherwise, it uses the take-along label mechanism via buildTakeAlongMap.
 func buildTakeAlongLabels(cluster *clusterv1.Cluster, cfg *Config) (map[string]string, []string) {
-	name := cluster.Name
-	namespace := cluster.Namespace
-	clusterLabels := cluster.Labels
-
 	if cfg.EnableAutoLabelCopy {
-		return buildAutoLabelCopy(clusterLabels), []string{}
+		return buildAutoLabelCopy(cluster.Labels), []string{}
 	}
 
-	// Original behavior: use take-along labels
-	takeAlongLabels := []string{}
+	return buildTakeAlongMap(
+		cluster.Name, cluster.Namespace,
+		cluster.Labels,
+		clusterTakeAlongKey, clusterTakenFromClusterKey,
+		"label",
+	)
+}
 
-	for k := range clusterLabels {
-		l, err := extractTakeAlongLabel(k)
-		if err != nil {
-			return nil, []string{err.Error()}
-		}
+// buildTakeAlongMap is the shared implementation for take-along labels and annotations.
+// It extracts keys marked with takeAlongPrefix, looks up their values in source,
+// and tracks them with takenFromPrefix markers.
+func buildTakeAlongMap(
+	clusterName, clusterNamespace string,
+	source map[string]string,
+	takeAlongPrefix, takenFromPrefix string,
+	kind string,
+) (map[string]string, []string) {
+	takeAlongKeys := []string{}
 
-		if l != "" {
-			takeAlongLabels = append(takeAlongLabels, l)
+	for k := range source {
+		if key, ok := strings.CutPrefix(k, takeAlongPrefix); ok {
+			if key == "" {
+				return nil, []string{fmt.Sprintf("invalid take-along %s, missing key after '/': %s", kind, k)}
+			}
+
+			takeAlongKeys = append(takeAlongKeys, key)
 		}
 	}
 
-	takeAlongLabelsMap := make(map[string]string)
+	result := make(map[string]string)
 
 	var errMsgs []string
 
-	if len(takeAlongLabels) > 0 {
-		for _, label := range takeAlongLabels {
-			if label != "" {
-				if _, ok := clusterLabels[label]; !ok {
-					errMsgs = append(errMsgs, fmt.Sprintf("take-along label '%s' not found on cluster resource: %s, namespace: %s. Ignoring", label, name, namespace))
+	for _, key := range takeAlongKeys {
+		if _, ok := source[key]; !ok {
+			errMsgs = append(errMsgs, fmt.Sprintf("take-along %s '%s' not found on cluster resource: %s, namespace: %s. Ignoring", kind, key, clusterName, clusterNamespace))
 
-					continue
-				}
-
-				takeAlongLabelsMap[label] = clusterLabels[label]
-				takeAlongLabelsMap[fmt.Sprintf("%s%s", clusterTakenFromClusterKey, label)] = ""
-			}
+			continue
 		}
+
+		result[key] = source[key]
+		result[takenFromPrefix+key] = ""
 	}
 
-	return takeAlongLabelsMap, errMsgs
+	return result, errMsgs
+}
+
+// buildAutoAnnotationCopy copies all cluster annotations except system and internal annotations.
+// It filters out:
+// - kubernetes.io/* annotations (system)
+// - cluster.x-k8s.io/* annotations (CAPI internal)
+// - capi-to-argocd/* annotations (controller internal)
+// - take-along-annotation.capi-to-argocd.* annotations (take-along markers)
+// - kubectl.kubernetes.io/* annotations (kubectl bookkeeping).
+func buildAutoAnnotationCopy(clusterAnnotations map[string]string) map[string]string {
+	copyAnnotations := make(map[string]string)
+
+	for key, value := range clusterAnnotations {
+		if strings.HasPrefix(key, "kubernetes.io/") ||
+			strings.HasPrefix(key, "cluster.x-k8s.io/") ||
+			strings.HasPrefix(key, "capi-to-argocd/") ||
+			strings.HasPrefix(key, annotationTakeAlongKey) ||
+			strings.HasPrefix(key, "kubectl.kubernetes.io/") {
+			continue
+		}
+
+		copyAnnotations[key] = value
+	}
+
+	return copyAnnotations
+}
+
+// buildTakeAlongAnnotations returns valid take-along annotations from a cluster.
+// If Config.EnableAutoAnnotationCopy is true, it copies all non-system annotations automatically.
+// Otherwise, it uses the take-along annotation mechanism via buildTakeAlongMap.
+func buildTakeAlongAnnotations(cluster *clusterv1.Cluster, cfg *Config) (map[string]string, []string) {
+	if cfg.EnableAutoAnnotationCopy {
+		return buildAutoAnnotationCopy(cluster.Annotations), []string{}
+	}
+
+	return buildTakeAlongMap(
+		cluster.Name, cluster.Namespace,
+		cluster.Annotations,
+		annotationTakeAlongKey, annotationTakenFromClusterKey,
+		"annotation",
+	)
 }
 
 // BuildNamespacedName returns the Kubernetes NamespacedName for the ArgoCD secret.
@@ -225,15 +287,24 @@ func (a *ArgoCluster) ConvertToSecret() (*corev1.Secret, error) {
 		mergedLabels[key] = value
 	}
 
+	var mergedAnnotations map[string]string
+	if len(a.TakeAlongAnnotations) > 0 {
+		mergedAnnotations = make(map[string]string, len(a.TakeAlongAnnotations))
+		for key, value := range a.TakeAlongAnnotations {
+			mergedAnnotations[key] = value
+		}
+	}
+
 	argoSecret := &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      a.NamespacedName.Name,
-			Namespace: a.NamespacedName.Namespace,
-			Labels:    mergedLabels,
+			Name:        a.NamespacedName.Name,
+			Namespace:   a.NamespacedName.Namespace,
+			Labels:      mergedLabels,
+			Annotations: mergedAnnotations,
 		},
 		Data: map[string][]byte{
 			"name":   []byte(a.ClusterName),

--- a/controllers/argo_cluster_test.go
+++ b/controllers/argo_cluster_test.go
@@ -222,13 +222,13 @@ func TestBuildAutoLabelCopy(t *testing.T) {
 		{
 			"Test with mixed labels (user + system)",
 			map[string]string{
-				"foo":                                  "bar",
-				"kubernetes.io/cluster-name":           "test",
+				"foo":                                 "bar",
+				"kubernetes.io/cluster-name":          "test",
 				"cluster.x-k8s.io/cluster-name":       "test",
-				"capi-to-argocd/owned":                 "true",
-				"take-along-label.capi-to-argocd.foo":  "",
-				"ignore-cluster.capi-to-argocd":        "",
-				"my.domain.com/environment":            "prod",
+				"capi-to-argocd/owned":                "true",
+				"take-along-label.capi-to-argocd.foo": "",
+				"ignore-cluster.capi-to-argocd":       "",
+				"my.domain.com/environment":           "prod",
 			},
 			map[string]string{
 				"foo":                       "bar",
@@ -238,7 +238,7 @@ func TestBuildAutoLabelCopy(t *testing.T) {
 		{
 			"Test with only system labels",
 			map[string]string{
-				"kubernetes.io/cluster-name":     "test",
+				"kubernetes.io/cluster-name":    "test",
 				"cluster.x-k8s.io/cluster-name": "test",
 			},
 			map[string]string{},
@@ -275,8 +275,8 @@ func TestBuildTakeAlongLabelsWithAutoMode(t *testing.T) {
 					Name:      "test",
 					Namespace: "test",
 					Labels: map[string]string{
-						"foo":                            "bar",
-						"my.domain.com/environment":      "prod",
+						"foo":                           "bar",
+						"my.domain.com/environment":     "prod",
 						"cluster.x-k8s.io/cluster-name": "test",
 					},
 				},
@@ -293,10 +293,10 @@ func TestBuildTakeAlongLabelsWithAutoMode(t *testing.T) {
 					Name:      "test",
 					Namespace: "test",
 					Labels: map[string]string{
-						"user-label":                     "value",
-						"kubernetes.io/cluster-name":     "test",
+						"user-label":                    "value",
+						"kubernetes.io/cluster-name":    "test",
 						"cluster.x-k8s.io/cluster-name": "test",
-						"capi-to-argocd/owned":           "true",
+						"capi-to-argocd/owned":          "true",
 					},
 				},
 			},
@@ -410,6 +410,305 @@ func TestValidateClusterIgnoreLabel(t *testing.T) {
 			assert.Equal(t, tt.testExpectedValue, result)
 		})
 	}
+}
+
+func TestBuildTakeAlongMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testName           string
+		source             map[string]string
+		testExpectedError  bool
+		testExpectedValues map[string]string
+	}{
+		{
+			"valid key extraction",
+			map[string]string{
+				"my-branch-name": "feat/test",
+				fmt.Sprintf("%s%s", annotationTakeAlongKey, "my-branch-name"):    "",
+				fmt.Sprintf("%s%s", annotationTakeAlongKey, "my.domain.com/rev"): "",
+				"my.domain.com/rev": "abc",
+			},
+			false,
+			map[string]string{
+				"my-branch-name":    "feat/test",
+				"my.domain.com/rev": "abc",
+				fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my-branch-name"):    "",
+				fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my.domain.com/rev"): "",
+			},
+		},
+		{
+			"empty key after prefix returns error",
+			map[string]string{
+				annotationTakeAlongKey: "",
+			},
+			true,
+			nil,
+		},
+		{
+			"no markers returns empty map",
+			map[string]string{
+				"some-annotation": "value",
+			},
+			false,
+			map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			result, errs := buildTakeAlongMap("test", "test", tt.source, annotationTakeAlongKey, annotationTakenFromClusterKey, "annotation")
+			if tt.testExpectedError {
+				assert.NotEmpty(t, errs)
+			} else {
+				assert.Empty(t, errs)
+				assert.Equal(t, tt.testExpectedValues, result)
+			}
+		})
+	}
+}
+
+func TestBuildAutoAnnotationCopy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testName           string
+		testMock           map[string]string
+		testExpectedValues map[string]string
+	}{
+		{
+			"Test with user annotations only",
+			map[string]string{
+				"my-branch-name":            "feat/test",
+				"my.domain.com/environment": "prod",
+			},
+			map[string]string{
+				"my-branch-name":            "feat/test",
+				"my.domain.com/environment": "prod",
+			},
+		},
+		{
+			"Test with mixed annotations (user + system)",
+			map[string]string{
+				"my-branch-name":                                   "feat/test",
+				"kubernetes.io/description":                        "test",
+				"cluster.x-k8s.io/paused":                          "true",
+				"capi-to-argocd/some-internal":                     "true",
+				"take-along-annotation.capi-to-argocd.foo":         "",
+				"kubectl.kubernetes.io/last-applied-configuration": "{}",
+				"my.domain.com/environment":                        "prod",
+			},
+			map[string]string{
+				"my-branch-name":            "feat/test",
+				"my.domain.com/environment": "prod",
+			},
+		},
+		{
+			"Test with only system annotations",
+			map[string]string{
+				"kubernetes.io/description":  "test",
+				"cluster.x-k8s.io/paused":    "true",
+				"kubectl.kubernetes.io/last": "{}",
+			},
+			map[string]string{},
+		},
+		{
+			"Test with nil annotations",
+			nil,
+			map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			result := buildAutoAnnotationCopy(tt.testMock)
+			assert.Equal(t, tt.testExpectedValues, result)
+		})
+	}
+}
+
+func TestBuildTakeAlongAnnotations(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		ArgoNamespace:            "argocd",
+		EnableAutoAnnotationCopy: false,
+	}
+
+	tests := []struct {
+		testName           string
+		testMock           *clusterv1.Cluster
+		testExpectedError  bool
+		testExpectedValues map[string]string
+	}{
+		{"Test with no take-along annotations",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"some-annotation": "value",
+					},
+				},
+			}, false, map[string]string{}},
+		{"Test with single take-along annotation",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"my-branch-name": "feat/test",
+						"other":          "ignored",
+						fmt.Sprintf("%s%s", annotationTakeAlongKey, "my-branch-name"): "",
+					},
+				},
+			}, false, map[string]string{
+				"my-branch-name": "feat/test",
+				fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my-branch-name"): "",
+			}},
+		{"Test with multiple take-along annotations",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"my-branch-name":         "feat/test",
+						"my.domain.com/revision": "abc123",
+						fmt.Sprintf("%s%s", annotationTakeAlongKey, "my-branch-name"):         "",
+						fmt.Sprintf("%s%s", annotationTakeAlongKey, "my.domain.com/revision"): "",
+					},
+				},
+			}, false, map[string]string{
+				"my-branch-name":         "feat/test",
+				"my.domain.com/revision": "abc123",
+				fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my-branch-name"):         "",
+				fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my.domain.com/revision"): "",
+			}},
+		{"Test with take-along annotation not found on cluster",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"other": "value",
+						fmt.Sprintf("%s%s", annotationTakeAlongKey, "missing"): "",
+					},
+				},
+			}, true, map[string]string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			v, errs := buildTakeAlongAnnotations(tt.testMock, cfg)
+			if tt.testExpectedError {
+				assert.NotEmpty(t, errs)
+			} else {
+				assert.Empty(t, errs)
+			}
+
+			assert.Equal(t, tt.testExpectedValues, v)
+		})
+	}
+}
+
+func TestBuildTakeAlongAnnotationsWithAutoMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		ArgoNamespace:            "argocd",
+		EnableAutoAnnotationCopy: true,
+	}
+
+	tests := []struct {
+		testName           string
+		testMock           *clusterv1.Cluster
+		testExpectedValues map[string]string
+	}{
+		{
+			"Test auto mode with user annotations",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"my-branch-name":            "feat/test",
+						"my.domain.com/environment": "prod",
+						"cluster.x-k8s.io/paused":   "true",
+					},
+				},
+			},
+			map[string]string{
+				"my-branch-name":            "feat/test",
+				"my.domain.com/environment": "prod",
+			},
+		},
+		{
+			"Test auto mode filters out system annotations",
+			&clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Annotations: map[string]string{
+						"user-annotation":                                  "value",
+						"kubernetes.io/description":                        "test",
+						"cluster.x-k8s.io/paused":                          "true",
+						"capi-to-argocd/internal":                          "true",
+						"kubectl.kubernetes.io/last-applied-configuration": "{}",
+					},
+				},
+			},
+			map[string]string{
+				"user-annotation": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			result, errs := buildTakeAlongAnnotations(tt.testMock, cfg)
+			assert.Empty(t, errs)
+			assert.Equal(t, tt.testExpectedValues, result)
+		})
+	}
+}
+
+func TestConvertToSecretWithAnnotations(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{ArgoNamespace: "argocd"}
+
+	a := MockArgoCluster(true, cfg)
+	a.TakeAlongAnnotations = map[string]string{
+		"my-branch-name": "feat/test",
+		fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my-branch-name"): "",
+	}
+
+	s, err := a.ConvertToSecret()
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Equal(t, "feat/test", s.Annotations["my-branch-name"])
+	assert.Equal(t, "", s.Annotations[fmt.Sprintf("%s%s", annotationTakenFromClusterKey, "my-branch-name")])
+}
+
+func TestConvertToSecretWithoutAnnotations(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{ArgoNamespace: "argocd"}
+
+	a := MockArgoCluster(true, cfg)
+	a.TakeAlongAnnotations = map[string]string{}
+
+	s, err := a.ConvertToSecret()
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Nil(t, s.Annotations)
 }
 
 func TestSentinelErrors(t *testing.T) {

--- a/controllers/capi2argo_reconciler.go
+++ b/controllers/capi2argo_reconciler.go
@@ -44,6 +44,10 @@ type Config struct {
 	// EnableAutoLabelCopy enables automatic copying of all non-system labels
 	// from CAPI Cluster resources to ArgoCD secrets.
 	EnableAutoLabelCopy bool
+
+	// EnableAutoAnnotationCopy enables automatic copying of all non-system
+	// annotations from CAPI Cluster resources to ArgoCD secrets.
+	EnableAutoAnnotationCopy bool
 }
 
 // LoadConfigFromEnv builds a Config from environment variables with sensible defaults.
@@ -56,13 +60,15 @@ func LoadConfigFromEnv() Config {
 	gc, _ := strconv.ParseBool(os.Getenv("ENABLE_GARBAGE_COLLECTION"))
 	ns, _ := strconv.ParseBool(os.Getenv("ENABLE_NAMESPACED_NAMES"))
 	al, _ := strconv.ParseBool(os.Getenv("ENABLE_AUTO_LABEL_COPY"))
+	aa, _ := strconv.ParseBool(os.Getenv("ENABLE_AUTO_ANNOTATION_COPY"))
 
 	return Config{
-		ArgoNamespace:           argoNS,
-		AllowedNamespaces:       parseNamespaceList(os.Getenv("ALLOWED_NAMESPACES")),
-		EnableGarbageCollection: gc,
-		EnableNamespacedNames:   ns,
-		EnableAutoLabelCopy:     al,
+		ArgoNamespace:            argoNS,
+		AllowedNamespaces:        parseNamespaceList(os.Getenv("ALLOWED_NAMESPACES")),
+		EnableGarbageCollection:  gc,
+		EnableNamespacedNames:    ns,
+		EnableAutoLabelCopy:      al,
+		EnableAutoAnnotationCopy: aa,
 	}
 }
 
@@ -262,46 +268,18 @@ func (r *Capi2Argo) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 		changed = true
 	}
 
-	// Check if take-along labels need synchronization.
-	log.V(1).Info("Checking take-along labels", "labels", argoCluster.TakeAlongLabels)
-
-	argoSecretTakenAlongLabels := []string{}
-
-	for l := range argoCluster.TakeAlongLabels {
-		if strings.HasPrefix(l, clusterTakenFromClusterKey) {
-			key := strings.Split(l, clusterTakenFromClusterKey)[1]
-			argoSecretTakenAlongLabels = append(argoSecretTakenAlongLabels, key)
-		}
+	// Synchronize take-along labels.
+	if syncMetadataMap(existingSecret.Labels, argoCluster.TakeAlongLabels, clusterTakenFromClusterKey, log, "label") {
+		changed = true
 	}
 
-	// Remove stale take-along labels.
-	for k := range existingSecret.Labels {
-		if strings.HasPrefix(k, clusterTakenFromClusterKey) {
-			key := strings.Split(k, clusterTakenFromClusterKey)[1]
-			if !slices.Contains(argoSecretTakenAlongLabels, key) {
-				delete(existingSecret.Labels, k)
-				delete(existingSecret.Labels, key)
-
-				changed = true
-			}
-		}
+	// Synchronize take-along annotations.
+	if existingSecret.Annotations == nil {
+		existingSecret.Annotations = make(map[string]string)
 	}
 
-	// Update labels with current values.
-	for k, v := range argoCluster.TakeAlongLabels {
-		if val, ok := existingSecret.Labels[k]; ok {
-			if val != v {
-				log.V(1).Info("Updating label in ArgoSecret", "label", k, "oldValue", val, "newValue", v)
-
-				existingSecret.Labels[k] = v
-				changed = true
-			}
-		} else {
-			log.V(1).Info("Adding label to ArgoSecret", "label", k)
-
-			existingSecret.Labels[k] = v
-			changed = true
-		}
+	if syncMetadataMap(existingSecret.Annotations, argoCluster.TakeAlongAnnotations, annotationTakenFromClusterKey, log, "annotation") {
+		changed = true
 	}
 
 	if changed {
@@ -367,6 +345,53 @@ func (r *Capi2Argo) deleteArgoSecretByLabels(ctx context.Context, log logr.Logge
 	log.Info("Deleted ArgoSecret", "name", secretList.Items[0].Name)
 
 	return nil
+}
+
+// syncMetadataMap synchronizes a desired map of key-value pairs into an existing
+// metadata map (labels or annotations). It removes stale entries tracked by the
+// takenFromPrefix marker and upserts current values. Returns true if any change was made.
+func syncMetadataMap(existing, desired map[string]string, takenFromPrefix string, log logr.Logger, kind string) bool {
+	changed := false
+
+	// Collect keys that are currently desired via the taken-from marker.
+	desiredTracked := []string{}
+
+	for k := range desired {
+		if key, ok := strings.CutPrefix(k, takenFromPrefix); ok {
+			desiredTracked = append(desiredTracked, key)
+		}
+	}
+
+	// Remove stale entries whose taken-from marker is no longer desired.
+	for k := range existing {
+		if key, ok := strings.CutPrefix(k, takenFromPrefix); ok {
+			if !slices.Contains(desiredTracked, key) {
+				delete(existing, k)
+				delete(existing, key)
+
+				changed = true
+			}
+		}
+	}
+
+	// Upsert desired entries.
+	for k, v := range desired {
+		if val, ok := existing[k]; ok {
+			if val != v {
+				log.V(1).Info("Updating "+kind+" in ArgoSecret", kind, k, "oldValue", val, "newValue", v)
+
+				existing[k] = v
+				changed = true
+			}
+		} else {
+			log.V(1).Info("Adding "+kind+" to ArgoSecret", kind, k)
+
+			existing[k] = v
+			changed = true
+		}
+	}
+
+	return changed
 }
 
 // ValidateObjectOwner checks whether reconciled object is managed by CACO or not.


### PR DESCRIPTION
## Summary

Kubernetes labels have character restrictions (no `/` in values), making them unsuitable for metadata like branch names (e.g. `feat/test`). This PR adds annotation synchronization from CAPI Cluster resources to ArgoCD secrets, complementing the existing label sync feature.

### Two modes of operation

- **Take-along annotations** (explicit): mark specific annotations for sync using `take-along-annotation.capi-to-argocd.<key>: ""`
- **Auto annotation copy** (`ENABLE_AUTO_ANNOTATION_COPY=true`): automatically copies all non-system annotations, filtering out `kubernetes.io/*`, `cluster.x-k8s.io/*`, `capi-to-argocd/*`, `kubectl.kubernetes.io/*`

### Changes

- **`controllers/argo_cluster.go`** — New `TakeAlongAnnotations` field on `ArgoCluster`, `extractTakeAlongAnnotation()`, `buildAutoAnnotationCopy()`, `buildTakeAlongAnnotations()` functions, annotation merge in `ConvertToSecret()`
- **`controllers/capi2argo_reconciler.go`** — `EnableAutoAnnotationCopy` config option, annotation sync + stale cleanup in reconciliation loop
- **`controllers/argo_cluster_test.go`** — 6 new test functions covering extract, auto-copy, take-along, and ConvertToSecret with/without annotations
- **`charts/`** — `autoAnnotationCopyEnabled` Helm value + `ENABLE_AUTO_ANNOTATION_COPY` env var in deployment template
- **`README.md`** — Documentation for both modes, updated configuration table

### Example use case

```yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: my-cluster
  annotations:
    my-branch-name: "feat/test"
    take-along-annotation.capi-to-argocd.my-branch-name: ""
```

Results in the ArgoCD secret having:
```yaml
metadata:
  annotations:
    my-branch-name: "feat/test"
    taken-from-cluster-annotation.capi-to-argocd.my-branch-name: ""
```

## Test plan

- [x] Unit tests for `extractTakeAlongAnnotation` (valid, complex, empty, standard keys)
- [x] Unit tests for `buildAutoAnnotationCopy` (user-only, mixed, system-only, nil)
- [x] Unit tests for `buildTakeAlongAnnotations` (none, single, multiple, missing)
- [x] Unit tests for auto mode with system annotation filtering
- [x] Unit tests for `ConvertToSecret` with and without annotations
- [x] `go build` and `go vet` pass
- [ ] Integration tests with envtest (existing tests still pass)