### PR TITLE
feat: use CAPI cluster name for ArgoCD secret name to fix compatibility with GKE clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ CACO is configured through environment variables (set via Helm values):
 | `ENABLE_NAMESPACED_NAMES` | `namespacedNamesEnabled` | `false` | Prepend cluster namespace to ArgoCD secret names to avoid collisions |
 | `ENABLE_AUTO_LABEL_COPY` | *(via `extraEnvVars`)* | `false` | Automatically copy all non-system labels from CAPI Cluster to ArgoCD secret |
 | `ENABLE_AUTO_ANNOTATION_COPY` | `autoAnnotationCopyEnabled` | `false` | Automatically copy all non-system annotations from CAPI Cluster to ArgoCD secret |
+| `ENABLE_CAPI_CLUSTER_NAME` | `capiClusterNameEnabled` | `false` | Use the CAPI Cluster name instead of the kubeconfig context name for the ArgoCD cluster name |
 
 ### CLI Flags
 

--- a/charts/capi2argo-cluster-operator/templates/deployment.yaml
+++ b/charts/capi2argo-cluster-operator/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
             - name: ENABLE_AUTO_ANNOTATION_COPY
               value: {{ .Values.autoAnnotationCopyEnabled | squote }}
             {{- end }}
+            {{- if .Values.capiClusterNameEnabled }}
+            - name: ENABLE_CAPI_CLUSTER_NAME
+              value: {{ .Values.capiClusterNameEnabled | squote }}
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/capi2argo-cluster-operator/values.yaml
+++ b/charts/capi2argo-cluster-operator/values.yaml
@@ -20,6 +20,7 @@ argoCDNamespace: "argocd"
 namespacedNamesEnabled: false
 garbageCollectionEnabled: true
 autoAnnotationCopyEnabled: false
+capiClusterNameEnabled: false
 
 dryRun: false
 debugMode: false

--- a/controllers/argo_cluster.go
+++ b/controllers/argo_cluster.go
@@ -81,7 +81,7 @@ func NewArgoCluster(c *CapiCluster, s *corev1.Secret, cluster *clusterv1.Cluster
 
 	return &ArgoCluster{
 		NamespacedName: BuildNamespacedName(s.ObjectMeta.Name, s.ObjectMeta.Namespace, cfg),
-		ClusterName:    BuildClusterName(c.KubeConfig.Clusters[0].Name, s.ObjectMeta.Namespace, cfg),
+		ClusterName:    BuildClusterName(resolveClusterNameSource(c, cfg), s.ObjectMeta.Namespace, cfg),
 		ClusterServer:  c.KubeConfig.Clusters[0].Cluster.Server,
 		ClusterLabels: map[string]string{
 			"capi-to-argocd/cluster-secret-name": c.Name + "-kubeconfig",
@@ -255,6 +255,17 @@ func BuildNamespacedName(s string, namespace string, cfg *Config) types.Namespac
 		Name:      "cluster-" + BuildClusterName(strings.TrimSuffix(s, "-kubeconfig"), namespace, cfg),
 		Namespace: cfg.ArgoNamespace,
 	}
+}
+
+// resolveClusterNameSource picks the source string for the ArgoCD cluster
+// name: the kubeconfig context name by default, or the CAPI Cluster name
+// when Config.EnableCapiClusterName is set.
+func resolveClusterNameSource(c *CapiCluster, cfg *Config) string {
+	if cfg.EnableCapiClusterName {
+		return c.Name
+	}
+
+	return c.KubeConfig.Clusters[0].Name
 }
 
 // BuildClusterName returns the cluster name with optional namespace prefix.

--- a/controllers/argo_cluster_test.go
+++ b/controllers/argo_cluster_test.go
@@ -360,6 +360,36 @@ func TestBuildNamespacedName(t *testing.T) {
 	}
 }
 
+func TestResolveClusterNameSource(t *testing.T) {
+	t.Parallel()
+
+	capiCluster := &CapiCluster{
+		Name: "my-cluster",
+		KubeConfig: KubeConfig{
+			Clusters: []Cluster{
+				{Name: "gke_my-project_europe-west1_my-cluster"},
+			},
+		},
+	}
+
+	tests := []struct {
+		testName           string
+		testConfig         *Config
+		testExpectedValues string
+	}{
+		{"defaults to kubeconfig context name", &Config{EnableCapiClusterName: false}, "gke_my-project_europe-west1_my-cluster"},
+		{"uses CAPI cluster name when enabled", &Config{EnableCapiClusterName: true}, "my-cluster"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			s := resolveClusterNameSource(capiCluster, tt.testConfig)
+			assert.Equal(t, tt.testExpectedValues, s)
+		})
+	}
+}
+
 func TestValidateClusterIgnoreLabel(t *testing.T) {
 	t.Parallel()
 

--- a/controllers/capi2argo_reconciler.go
+++ b/controllers/capi2argo_reconciler.go
@@ -48,6 +48,10 @@ type Config struct {
 	// EnableAutoAnnotationCopy enables automatic copying of all non-system
 	// annotations from CAPI Cluster resources to ArgoCD secrets.
 	EnableAutoAnnotationCopy bool
+
+	// EnableCapiClusterName uses the CAPI Cluster's name instead of the
+	// kubeconfig context name for the ArgoCD cluster name field.
+	EnableCapiClusterName bool
 }
 
 // LoadConfigFromEnv builds a Config from environment variables with sensible defaults.
@@ -61,6 +65,7 @@ func LoadConfigFromEnv() Config {
 	ns, _ := strconv.ParseBool(os.Getenv("ENABLE_NAMESPACED_NAMES"))
 	al, _ := strconv.ParseBool(os.Getenv("ENABLE_AUTO_LABEL_COPY"))
 	aa, _ := strconv.ParseBool(os.Getenv("ENABLE_AUTO_ANNOTATION_COPY"))
+	cn, _ := strconv.ParseBool(os.Getenv("ENABLE_CAPI_CLUSTER_NAME"))
 
 	return Config{
 		ArgoNamespace:            argoNS,
@@ -69,6 +74,7 @@ func LoadConfigFromEnv() Config {
 		EnableNamespacedNames:    ns,
 		EnableAutoLabelCopy:      al,
 		EnableAutoAnnotationCopy: aa,
+		EnableCapiClusterName:    cn,
 	}
 }
 

--- a/controllers/capi2argo_reconciler_test.go
+++ b/controllers/capi2argo_reconciler_test.go
@@ -38,6 +38,7 @@ var (
 		EnableGarbageCollection: false,
 		EnableNamespacedNames:   false,
 		EnableAutoLabelCopy:     false,
+		EnableCapiClusterName:   false,
 	}
 )
 


### PR DESCRIPTION
At present if you try and run this Operator with a GKE provisioned CAPI cluster you'll find issues because the cluster_name defaults to the GKE standard, which is `gke_<region>_<project>_<cluster>`. Now `_`s are not allowed in this field so this causes lots of problems. 

The solution (and ironically the one employed by the CronJob I'd like this operator replace) is to take the CAPI Cluster Name instead of the name from the KubeConfig. This PR enables that and gates it behind an `ENABLE_CAPI_CLUSTER_NAME` toggle which defaults to false (so no one is surprised when they install/upgrade this).